### PR TITLE
Allow discover_filename() to raise FileNotFoundError

### DIFF
--- a/launchd/plist.py
+++ b/launchd/plist.py
@@ -41,7 +41,7 @@ def discover_filename(label: str, scopes=None) -> str:
         plistfilename = compute_filename(label, thisscope)
         if os.path.isfile(plistfilename):
             return plistfilename
-    raise FileNotFoundError(f"{}, {}".format(label, scopes))
+    raise FileNotFoundError(f"{label}, {scopes}")
 
 
 def read(label, scope=None):

--- a/launchd/plist.py
+++ b/launchd/plist.py
@@ -26,7 +26,7 @@ def compute_filename(label, scope):
     return os.path.join(compute_directory(scope), label + ".plist")
 
 
-def discover_filename(label, scopes=None):
+def discover_filename(label: str, scopes=None) -> str:
     """
     Check the filesystem for the existence of a .plist file matching the job label.
     Optionally specify one or more scopes to search (default all).
@@ -34,15 +34,14 @@ def discover_filename(label, scopes=None):
     :param label: string
     :param scope: tuple or list or oneOf(USER, USER_ADMIN, DAEMON_ADMIN, USER_OS, DAEMON_OS)
     """
-    if scopes is None:
-        scopes = list(PLIST_LOCATIONS)
-    elif not isinstance(scopes, (list, tuple)):
+    scopes = scopes or tuple(PLIST_LOCATIONS)
+    if not isinstance(scopes, (list, tuple)):
         scopes = (scopes, )
     for thisscope in scopes:
         plistfilename = compute_filename(label, thisscope)
         if os.path.isfile(plistfilename):
             return plistfilename
-    return None
+    raise FileNotFoundError(f"{}, {}".format(label, scopes))
 
 
 def read(label, scope=None):

--- a/launchd/tests/plist.py
+++ b/launchd/tests/plist.py
@@ -46,8 +46,8 @@ class PlistToolTest(unittest.TestCase):
         fname2 = plist.discover_filename("com.apple.kextd")
         self.assertTrue(os.path.isfile(fname2))
 
-        fname = plist.discover_filename("com.apple.kextd", plist.USER)
-        self.assertEqual(None, fname)
+        with self.assertRaises(FileNotFoundError):
+            fname = plist.discover_filename("com.apple.kextd", plist.USER)
 
     @unittest.skipUnless(sys.platform.startswith("darwin"), "requires OS X")
     def test_read(self):
@@ -75,8 +75,8 @@ class PlistToolPersistencyTest(unittest.TestCase):
         sample_label = "com.example.unittest"
         sample_props = {"Label": "testlaunchdwrapper_python"}
 
-        fname = plist.discover_filename(sample_label, plist.USER)
-        self.assertEqual(None, fname)
+        with self.assertRaises(FileNotFoundError):
+            fname = plist.discover_filename(sample_label, plist.USER)
         plist.write(sample_label, sample_props, plist.USER)
 
         fname = plist.discover_filename(sample_label, plist.USER)


### PR DESCRIPTION
As discussed at https://github.com/infothrill/python-launchd/pull/12#issuecomment-1521357382